### PR TITLE
Upgrade Jackson to fix vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         jcenter()
         maven {
-            url "http://repo.jenkins-ci.org/releases/"
+            url "https://repo.jenkins-ci.org/releases/"
         }
     }
     dependencies {
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.fasterxml.jackson.core:jackson-databind:2.4.4"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.12.7.2"
     compile "org.jenkins-ci:symbol-annotation:1.14"
     testCompile "org.mockito:mockito-core:1.10.19"
 }


### PR DESCRIPTION
The `jackson-databind` dependency has over 58 vulnerabilities including Criticals and Highs.
This PR bumps the dependency to avoid vulnerabilities.